### PR TITLE
Add yardoc documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown

--- a/README.md
+++ b/README.md
@@ -41,29 +41,41 @@ A `LinkedContentItem` built from a taxon can access all *narrower term* taxons b
 A taxon may have many child taxons, but can only have one or zero parents.
 
 ```ruby
-puts taxonomy.tree             # All taxons in this branch of the taxonomy
-puts taxonomy.descendants      # Just the taxons that fall under this one
-puts taxonomy.children         # All direct children
-puts taxonomy.parent           # The direct parent
-puts taxonomy.ancestors        # The path from the root of the taxonomy to the parent taxon
-puts taxonomy.breadcrumb_trail # The path from the root of the taxonomy to this taxon
+taxon.children
+# => [LinkedContentItem(name: child-1-id, ...), LinkedContentItem(name: child-2, ...)]
+
+taxon.parent
+# => LinkedContentItem(name: root, ...)
+
+taxon.breadcrumb_trail
+# => [LinkedContentItem(name: root, ...), LinkedContentItem(name: taxon, ...)]
 ```
 
 A `LinkedContentItem` built from an content_item that isn't a taxon can access all taxons associated with it.
 
 ```ruby
-puts taxonomy.taxons                # Directly tagged taxons
-puts taxonomy.taxons_with_ancestors # All taxons that the content can be found in
-puts taxonomy.parent                # nil
-puts taxonomy.children              # []
+content_item.taxons
+# => [LinkedContentItem(name: taxon, ...),
+#     LinkedContentItem(name: another-taxon, ...)]
+
+content_item.taxons_with_ancestors
+# => [LinkedContentItem(name: root, ...),
+#     LinkedContentItem(name: taxon-parent, ...),
+#     LinkedContentItem(name: taxon, ...),
+#     LinkedContentItem(name: another-taxon, ...)]
 ```
 
 ## Nomenclature
 
 - **Taxonomy**: The hierarchy of topics used to classify content by subject on GOV.UK. Not all content is tagged to the taxonomy. We are rolling out the taxonomy and navigation theme-by-theme.
 - **Taxon**: Any topic within the taxonomy.
-- **ContentItem**: A distinct version of a document. A taxon is also a type of content item.
+- **Content Item**: A distinct version of a document. A taxon is also a type of content item.
 
+## Documentation
+
+To run a Yard server locally to preview documentation, run:
+
+    $ bundle exec yard server --reload
 
 ## Contributing
 

--- a/govuk_taxonomy_helpers.gemspec
+++ b/govuk_taxonomy_helpers.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "gem_publisher", "~> 1.5.0"
   spec.add_development_dependency "govuk-lint", "~> 1.2.1"
   spec.add_development_dependency "pry-byebug", "~> 3.4"
-  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "yard", "~> 0.9.8"
 end

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -2,6 +2,14 @@ require 'govuk_taxonomy_helpers/linked_content_item'
 
 module GovukTaxonomyHelpers
   class LinkedContentItem
+    # Extract a LinkedContentItem from publishing api response data.
+    #
+    # @param content_item [Hash] Publishing API `get_content` response hash
+    # @param expanded_links [Hash] Publishing API `get_expanded_links` response hash
+    # @param name_field [String] The field to use for content item names
+    # @return [LinkedContentItem]
+    # @see http://www.rubydoc.info/gems/gds-api-adapters/GdsApi/PublishingApiV2#get_content-instance_method
+    # @see http://www.rubydoc.info/gems/gds-api-adapters/GdsApi%2FPublishingApiV2:get_expanded_links
     def self.from_publishing_api(content_item:, expanded_links:, name_field: "title")
       PublishingApiResponse.new(
         content_item: content_item,


### PR DESCRIPTION
Add method level documentation and only include basic examples in the README.

Branched on top of https://github.com/alphagov/govuk_taxonomy_helpers/pull/1