### PR TITLE
Separate internal_name from title

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/README.md
+++ b/README.md
@@ -42,27 +42,27 @@ A taxon may have many child taxons, but can only have one or zero parents.
 
 ```ruby
 taxon.children
-# => [LinkedContentItem(name: child-1-id, ...), LinkedContentItem(name: child-2, ...)]
+# => [LinkedContentItem(title: child-1-id, ...), LinkedContentItem(title: child-2, ...)]
 
 taxon.parent
-# => LinkedContentItem(name: root, ...)
+# => LinkedContentItem(title: root, ...)
 
 taxon.breadcrumb_trail
-# => [LinkedContentItem(name: root, ...), LinkedContentItem(name: taxon, ...)]
+# => [LinkedContentItem(title: root, ...), LinkedContentItem(title: taxon, ...)]
 ```
 
 A `LinkedContentItem` built from an content_item that isn't a taxon can access all taxons associated with it.
 
 ```ruby
 content_item.taxons
-# => [LinkedContentItem(name: taxon, ...),
-#     LinkedContentItem(name: another-taxon, ...)]
+# => [LinkedContentItem(title: taxon, ...),
+#     LinkedContentItem(title: another-taxon, ...)]
 
 content_item.taxons_with_ancestors
-# => [LinkedContentItem(name: root, ...),
-#     LinkedContentItem(name: taxon-parent, ...),
-#     LinkedContentItem(name: taxon, ...),
-#     LinkedContentItem(name: another-taxon, ...)]
+# => [LinkedContentItem(title: root, ...),
+#     LinkedContentItem(title: taxon-parent, ...),
+#     LinkedContentItem(title: taxon, ...),
+#     LinkedContentItem(title: another-taxon, ...)]
 ```
 
 ## Nomenclature

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require "bundler/gem_tasks"
-

--- a/govuk_taxonomy_helpers.gemspec
+++ b/govuk_taxonomy_helpers.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = GovukTaxonomyHelpers::VERSION
   spec.authors       = ["Mat Moore"]
   spec.email         = ["mat.moore@digital.cabinet-office.gov.uk"]
-  spec.summary       = %q{Parses the taxonomy of GOV.UK into a browseable tree structure.}
+  spec.summary       = "Parses the taxonomy of GOV.UK into a browseable tree structure."
   spec.homepage      = "https://github.com/alphagov/govuk_taxonomy_helpers"
   spec.license       = "MIT"
 

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -1,5 +1,4 @@
 module GovukTaxonomyHelpers
-
   # A LinkedContentItem can be anything that has a content store representation
   # on GOV.UK.
   #

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -9,16 +9,18 @@ module GovukTaxonomyHelpers
   # Taxon instances can have an optional parent and any number of child taxons.
   class LinkedContentItem
     extend Forwardable
-    attr_reader :name, :content_id, :base_path, :children
+    attr_reader :title, :content_id, :base_path, :children, :internal_name
     attr_accessor :parent
     attr_reader :taxons
     def_delegators :tree, :map, :each
 
-    # @param name [String] an internal or external name for the content item
+    # @param title [String] the user facing name for the content item
     # @param base_path [String] the relative URL, starting with a leading "/"
     # @param content_id [UUID] unique identifier of the content item
-    def initialize(name:, base_path:, content_id:)
-      @name = name
+    # @param internal_name [String] an internal name for the content item
+    def initialize(title:, base_path:, content_id:, internal_name: nil)
+      @title = title
+      @internal_name = internal_name
       @content_id = content_id
       @base_path = base_path
       @children = []
@@ -100,7 +102,11 @@ module GovukTaxonomyHelpers
 
     # @return [String] the string representation of the content item
     def inspect
-      "LinkedContentItem(name: #{name}, content_id: #{content_id}, base_path: #{base_path})"
+      if internal_name.nil?
+        "LinkedContentItem(title: '#{title}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      else
+        "LinkedContentItem(title: '#{title}', internal_name: '#{internal_name}', content_id: '#{content_id}', base_path: '#{base_path}')"
+      end
     end
   end
 end

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -39,7 +39,7 @@ module GovukTaxonomyHelpers
       taxons = expanded_links_response["expanded_links"]["taxons"]
 
       if !child_taxons.nil?
-        child_nodes = child_taxons.each do |child|
+        child_taxons.each do |child|
           linked_content_item << parse_nested_child(child)
         end
       end
@@ -52,7 +52,7 @@ module GovukTaxonomyHelpers
       end
 
       if !taxons.nil?
-        taxon_nodes = taxons.each do |taxon|
+        taxons.each do |taxon|
           taxon_node = parse_nested_parent(taxon)
           linked_content_item.add_taxon(taxon_node)
         end
@@ -70,7 +70,7 @@ module GovukTaxonomyHelpers
       child_taxons = nested_item["links"]["child_taxons"]
 
       if !child_taxons.nil?
-        child_nodes = child_taxons.each do |child|
+        child_taxons.each do |child|
           nested_linked_content_item << parse_nested_child(child)
         end
       end

--- a/lib/govuk_taxonomy_helpers/version.rb
+++ b/lib/govuk_taxonomy_helpers/version.rb
@@ -1,3 +1,3 @@
 module GovukTaxonomyHelpers
-  VERSION = "0.0.1"
+  VERSION = "0.0.1".freeze
 end

--- a/spec/linked_content_item_spec.rb
+++ b/spec/linked_content_item_spec.rb
@@ -73,7 +73,13 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
   end
 
   context "taxon with ancestors" do
-    let(:child_node_2) {GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")}
+    let(:child_node_2) do
+      GovukTaxonomyHelpers::LinkedContentItem.new(
+        title: "child-2-id",
+        content_id: "abc",
+        base_path: "/child-2-id"
+      )
+    end
 
     before do
       root_node << child_node_1
@@ -111,9 +117,9 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
     describe "#taxons" do
       let(:content_item) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        title: "content",
-        content_id: "abc",
-        base_path: "/content"
+          title: "content",
+          content_id: "abc",
+          base_path: "/content"
         )
       end
 
@@ -127,17 +133,17 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
     describe "#taxons_with_ancestors" do
       let(:another_taxon) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        title: "another-taxon",
-        content_id: "abc",
-        base_path: "/another-taxon"
+          title: "another-taxon",
+          content_id: "abc",
+          base_path: "/another-taxon"
         )
       end
 
       let(:content_item) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        title: "content",
-        content_id: "abc",
-        base_path: "/content"
+          title: "content",
+          content_id: "abc",
+          base_path: "/content"
         )
       end
 

--- a/spec/linked_content_item_spec.rb
+++ b/spec/linked_content_item_spec.rb
@@ -2,8 +2,8 @@ require_relative 'spec_helper'
 require 'govuk_taxonomy_helpers/linked_content_item'
 
 RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
-  let(:root_node) { GovukTaxonomyHelpers::LinkedContentItem.new(name: "root-id", content_id: "abc", base_path: "/root-id") }
-  let(:child_node_1) { GovukTaxonomyHelpers::LinkedContentItem.new(name: "child-1-id", content_id: "abc", base_path: "/child-1-id") }
+  let(:root_node) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "root-id", content_id: "abc", base_path: "/root-id") }
+  let(:child_node_1) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-1-id", content_id: "abc", base_path: "/child-1-id") }
 
   describe "#<<(child_node)" do
     it "makes one node the child of another node" do
@@ -17,8 +17,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
   describe "#tree" do
     context "given a node with a tree of successors" do
       it "returns an array representing a pre-order traversal of the tree" do
-        child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(name: "child-2-id", content_id: "abc", base_path: "/child-2-id")
-        child_node_3 = GovukTaxonomyHelpers::LinkedContentItem.new(name: "child-3-id", content_id: "abc", base_path: "/child-3-id")
+        child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
+        child_node_3 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-3-id", content_id: "abc", base_path: "/child-3-id")
 
         root_node << child_node_1
         child_node_1 << child_node_3
@@ -26,14 +26,14 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
 
         expect(root_node.tree.count).to eq 4
         expect(root_node.tree.first).to eq root_node
-        expect(root_node.tree.map(&:name)).to eq %w(root-id child-1-id child-3-id child-2-id)
-        expect(child_node_1.tree.map(&:name)).to eq %w(child-1-id child-3-id child-2-id)
+        expect(root_node.tree.map(&:title)).to eq %w(root-id child-1-id child-3-id child-2-id)
+        expect(child_node_1.tree.map(&:title)).to eq %w(child-1-id child-3-id child-2-id)
       end
     end
 
     context "given a single node" do
       it "returns an array containing only that node" do
-        expect(root_node.tree.map(&:name)).to eq %w(root-id)
+        expect(root_node.tree.map(&:title)).to eq %w(root-id)
       end
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
 
   describe "#depth" do
     it "returns the depth of the node in its tree" do
-      child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(name: "child-2-id", content_id: "abc", base_path: "/child-2-id")
+      child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
       root_node << child_node_1
       child_node_1 << child_node_2
 
@@ -73,7 +73,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
   end
 
   context "taxon with ancestors" do
-    let(:child_node_2) {GovukTaxonomyHelpers::LinkedContentItem.new(name: "child-2-id", content_id: "abc", base_path: "/child-2-id")}
+    let(:child_node_2) {GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")}
 
     before do
       root_node << child_node_1
@@ -82,17 +82,17 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
 
     describe "#breadcrumb_trail" do
       it "includes the ancestors plus the content item itself" do
-        expect(child_node_2.breadcrumb_trail.map(&:name)).to eq %w(root-id child-1-id child-2-id)
+        expect(child_node_2.breadcrumb_trail.map(&:title)).to eq %w(root-id child-1-id child-2-id)
       end
 
       it "is just contains itself for the root node" do
-        expect(root_node.breadcrumb_trail.map(&:name)).to eq %w(root-id)
+        expect(root_node.breadcrumb_trail.map(&:title)).to eq %w(root-id)
       end
     end
 
     describe "#ancestors" do
       it "includes the ancestors but not the content item itself" do
-        expect(child_node_2.ancestors.map(&:name)).to eq %w(root-id child-1-id)
+        expect(child_node_2.ancestors.map(&:title)).to eq %w(root-id child-1-id)
       end
 
       it "is the reverse of #descendants" do
@@ -111,7 +111,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
     describe "#taxons" do
       let(:content_item) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        name: "content",
+        title: "content",
         content_id: "abc",
         base_path: "/content"
         )
@@ -120,14 +120,14 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
       it "includes only the directly linked taxons" do
         content_item.add_taxon(child_node_2)
 
-        expect(content_item.taxons.map(&:name)).to eq ["child-2-id"]
+        expect(content_item.taxons.map(&:title)).to eq ["child-2-id"]
       end
     end
 
     describe "#taxons_with_ancestors" do
       let(:another_taxon) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        name: "another-taxon",
+        title: "another-taxon",
         content_id: "abc",
         base_path: "/another-taxon"
         )
@@ -135,7 +135,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
 
       let(:content_item) do
         GovukTaxonomyHelpers::LinkedContentItem.new(
-        name: "content",
+        title: "content",
         content_id: "abc",
         base_path: "/content"
         )
@@ -145,7 +145,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
         content_item.add_taxon(child_node_2)
         content_item.add_taxon(another_taxon)
 
-        expect(content_item.taxons_with_ancestors.map(&:name).sort).to eq %w(another-taxon child-1-id child-2-id root-id)
+        expect(content_item.taxons_with_ancestors.map(&:title).sort).to eq %w(another-taxon child-1-id child-2-id root-id)
       end
     end
   end

--- a/spec/publishing_api_response_spec.rb
+++ b/spec/publishing_api_response_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
       "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
       "base_path" => "/taxon",
       "title" => "Taxon",
-      "internal_name" => "My lovely taxon"
+      "details" => {
+        "internal_name" => "My lovely taxon"
+      }
     }
   end
 
@@ -24,7 +26,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandchild-1",
         "title" => "Grandchild 1",
-        "internal_name" => "Root > Child > Grandchild 1",
+        "details" => {
+          "internal_name" => "GC 1",
+        },
         "links" => {}
       }
 
@@ -32,7 +36,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "94aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandchild-2",
         "title" => "Grandchild 2",
-        "internal_name" => "Root > Child > Grandchild 2",
+        "details" => {
+          "internal_name" => "GC 2",
+        },
         "links" => {}
       }
 
@@ -40,7 +46,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/child-1",
         "title" => "Child 1",
-        "internal_name" => "Root > Child 1",
+        "details" => {
+          "internal_name" => "C 1",
+        },
         "links" => {
           "child_taxons" => [
             grandchild_1,
@@ -57,10 +65,16 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
       }
     end
 
-    it "parses each level of taxons" do
-      expect(linked_content_item.name).to eq("Taxon")
-      expect(linked_content_item.children.map(&:name)).to eq (['Child 1'])
-      expect(linked_content_item.children.first.children.map(&:name)).to eq(["Grandchild 1", "Grandchild 2"])
+    it "parses titles" do
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.children.map(&:title)).to eq (['Child 1'])
+      expect(linked_content_item.children.first.children.map(&:title)).to eq(["Grandchild 1", "Grandchild 2"])
+    end
+
+    it "parses internal names" do
+      expect(linked_content_item.internal_name).to eq("My lovely taxon")
+      expect(linked_content_item.children.map(&:internal_name)).to eq (['C 1'])
+      expect(linked_content_item.children.first.children.map(&:internal_name)).to eq(["GC 1", "GC 2"])
     end
   end
 
@@ -73,7 +87,7 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "parses each level of taxons" do
-      expect(linked_content_item.name).to eq("Taxon")
+      expect(linked_content_item.title).to eq("Taxon")
       expect(linked_content_item.children).to be_empty
     end
   end
@@ -84,7 +98,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/child-1",
         "title" => "Child 1",
-        "internal_name" => "Root > Child 1",
+        "details" => {
+          "internal_name" => "C 1",
+        },
         "links" => {}
       }
 
@@ -92,7 +108,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/child-2",
         "title" => "Child 2",
-        "internal_name" => "Root > Child 2",
+        "details" => {
+          "internal_name" => "C 2",
+        },
         "links" => {}
       }
 
@@ -105,8 +123,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "parses each level of taxons" do
-      expect(linked_content_item.name).to eq("Taxon")
-      expect(linked_content_item.children.map(&:name)).to eq(["Child 1", "Child 2"])
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.children.map(&:title)).to eq(["Child 1", "Child 2"])
       expect(linked_content_item.children.map(&:children)).to all(be_empty)
     end
   end
@@ -117,6 +135,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandparent-1",
         "title" => "Grandparent 1",
+        "details" => {
+          "internal_name" => "GP 1",
+        },
         "links" => {}
       }
 
@@ -124,6 +145,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-1",
         "title" => "Parent 1",
+        "details" => {
+          "internal_name" => "P 1",
+        },
         "links" => {
           "parent_taxons" => [
             grandparent_1
@@ -140,9 +164,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "parses the ancestors" do
-      expect(linked_content_item.name).to eq("Taxon")
-      expect(linked_content_item.parent.name).to eq("Parent 1")
-      expect(linked_content_item.ancestors.map(&:name)).to eq(["Grandparent 1", "Parent 1"])
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.parent.title).to eq("Parent 1")
+      expect(linked_content_item.ancestors.map(&:title)).to eq(["Grandparent 1", "Parent 1"])
     end
   end
 
@@ -153,6 +177,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-1",
         "title" => "Parent 1",
+        "details" => {
+          "internal_name" => "P 1",
+        },
         "links" => {}
       }
 
@@ -165,9 +192,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "parses the ancestors" do
-      expect(linked_content_item.name).to eq("Taxon")
-      expect(linked_content_item.parent.name).to eq("Parent 1")
-      expect(linked_content_item.ancestors.map(&:name)).to eq(["Parent 1"])
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.parent.title).to eq("Parent 1")
+      expect(linked_content_item.ancestors.map(&:title)).to eq(["Parent 1"])
     end
   end
 
@@ -180,9 +207,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "parses the ancestors" do
-      expect(linked_content_item.name).to eq("Taxon")
+      expect(linked_content_item.title).to eq("Taxon")
       expect(linked_content_item.parent).to be_nil
-      expect(linked_content_item.ancestors.map(&:name)).to be_empty
+      expect(linked_content_item.ancestors.map(&:title)).to be_empty
     end
   end
 
@@ -192,6 +219,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-1",
         "title" => "Parent 1",
+        "details" => {
+          "internal_name" => "P 1",
+        },
         "links" => {}
       }
 
@@ -199,6 +229,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-2",
         "title" => "Parent 2",
+        "details" => {
+          "internal_name" => "P 2",
+        },
         "links" => {}
       }
 
@@ -211,9 +244,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     end
 
     it "uses only the first parent" do
-      expect(linked_content_item.name).to eq("Taxon")
-      expect(linked_content_item.parent.name).to eq("Parent 1")
-      expect(linked_content_item.ancestors.map(&:name)).to eq(["Parent 1"])
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.parent.title).to eq("Parent 1")
+      expect(linked_content_item.ancestors.map(&:title)).to eq(["Parent 1"])
     end
   end
 
@@ -223,6 +256,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "22aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandparent-1",
         "title" => "Grandparent 1",
+        "details" => {
+          "internal_name" => "GP 1",
+        },
         "links" => {}
       }
 
@@ -230,6 +266,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "11aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-1",
         "title" => "Parent 1",
+        "details" => {
+          "internal_name" => "P 1",
+        },
         "links" => {
           "parent_taxons" => [grandparent_1]
         }
@@ -239,6 +278,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "00aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/this-is-a-taxon",
         "title" => "Taxon 1",
+        "details" => {
+          "internal_name" => "T 1",
+        },
         "links" => {
           "parent_taxons" => [parent_1]
         }
@@ -248,6 +290,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "03aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandparent-2",
         "title" => "Grandparent 2",
+        "details" => {
+          "internal_name" => "GP 2",
+        },
         "links" => {}
       }
 
@@ -255,6 +300,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "02aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/parent-2",
         "title" => "Parent 2",
+        "details" => {
+          "internal_name" => "P 2",
+        },
         "links" => {
           "parent_taxons" => [grandparent_2]
         }
@@ -264,6 +312,9 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "01aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/this-is-also-a-taxon",
         "title" => "Taxon 2",
+        "details" => {
+          "internal_name" => "T 2",
+        },
         "links" => {
           "parent_taxons" => [parent_2]
         }
@@ -279,8 +330,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
 
     it "parses the taxons and their ancestors" do
       expect(linked_content_item.parent).to be_nil
-      expect(linked_content_item.taxons.map(&:name)).to eq(["Taxon 1", "Taxon 2"])
-      expect(linked_content_item.taxons_with_ancestors.map(&:name).sort).to eq(
+      expect(linked_content_item.taxons.map(&:title)).to eq(["Taxon 1", "Taxon 2"])
+      expect(linked_content_item.taxons_with_ancestors.map(&:title).sort).to eq(
         [
           "Grandparent 1", "Grandparent 2",
           "Parent 1", "Parent 2",

--- a/spec/publishing_api_response_spec.rb
+++ b/spec/publishing_api_response_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
 
     it "parses titles" do
       expect(linked_content_item.title).to eq("Taxon")
-      expect(linked_content_item.children.map(&:title)).to eq (['Child 1'])
+      expect(linked_content_item.children.map(&:title)).to eq(['Child 1'])
       expect(linked_content_item.children.first.children.map(&:title)).to eq(["Grandchild 1", "Grandchild 2"])
     end
 
     it "parses internal names" do
       expect(linked_content_item.internal_name).to eq("My lovely taxon")
-      expect(linked_content_item.children.map(&:internal_name)).to eq (['C 1'])
+      expect(linked_content_item.children.map(&:internal_name)).to eq(['C 1'])
       expect(linked_content_item.children.first.children.map(&:internal_name)).to eq(["GC 1", "GC 2"])
     end
   end


### PR DESCRIPTION
Taxons have an internal name and an external name, both of which are useful.

I originally thought we could have a general purpose name and decide at parse
time, but I think it's better to expose both of them.

The previous code didn't work for internal_name because it lives in the details
hash.