### PR TITLE
[DO NOT MERGE] Add support for draft taxons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Added `draft` flag to differentiate between draft and live taxons
+
 ## 0.0.1
 
 * Gem created

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ content_item.taxons_with_ancestors
 - **Taxonomy**: The hierarchy of topics used to classify content by subject on GOV.UK. Not all content is tagged to the taxonomy. We are rolling out the taxonomy and navigation theme-by-theme.
 - **Taxon**: Any topic within the taxonomy.
 - **Content Item**: A distinct version of a document. A taxon is also a type of content item.
+- **Draft**: A content item which has not yet been published. Draft taxons do not appear on the live site but can have documents tagged to them.
 
 ## Documentation
 

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -8,7 +8,7 @@ module GovukTaxonomyHelpers
   # Taxon instances can have an optional parent and any number of child taxons.
   class LinkedContentItem
     extend Forwardable
-    attr_reader :title, :content_id, :base_path, :children, :internal_name
+    attr_reader :title, :content_id, :base_path, :children, :internal_name, :draft
     attr_accessor :parent
     attr_reader :taxons
     def_delegators :tree, :map, :each
@@ -17,11 +17,13 @@ module GovukTaxonomyHelpers
     # @param base_path [String] the relative URL, starting with a leading "/"
     # @param content_id [UUID] unique identifier of the content item
     # @param internal_name [String] an internal name for the content item
-    def initialize(title:, base_path:, content_id:, internal_name: nil)
+    # @param draft [Boolean] whether the content item is a draft
+    def initialize(title:, base_path:, content_id:, internal_name: nil, draft:)
       @title = title
       @internal_name = internal_name
       @content_id = content_id
       @base_path = base_path
+      @draft = draft
       @children = []
       @taxons = []
     end
@@ -102,9 +104,9 @@ module GovukTaxonomyHelpers
     # @return [String] the string representation of the content item
     def inspect
       if internal_name.nil?
-        "LinkedContentItem(title: '#{title}', content_id: '#{content_id}', base_path: '#{base_path}')"
+        "LinkedContentItem(title: '#{title}', content_id: '#{content_id}', base_path: '#{base_path}', draft: '#{draft}')"
       else
-        "LinkedContentItem(title: '#{title}', internal_name: '#{internal_name}', content_id: '#{content_id}', base_path: '#{base_path}')"
+        "LinkedContentItem(title: '#{title}', internal_name: '#{internal_name}', content_id: '#{content_id}', base_path: '#{base_path}', draft: '#{draft}')"
       end
     end
   end

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -29,7 +29,8 @@ module GovukTaxonomyHelpers
         title: content_item["title"],
         internal_name: details["internal_name"],
         content_id: content_item["content_id"],
-        base_path: content_item["base_path"]
+        base_path: content_item["base_path"],
+        draft: content_item["draft"]
       )
 
       add_expanded_links(expanded_links)
@@ -71,7 +72,8 @@ module GovukTaxonomyHelpers
         title: nested_item["title"],
         internal_name: details["internal_name"],
         content_id: nested_item["content_id"],
-        base_path: nested_item["base_path"]
+        base_path: nested_item["base_path"],
+        draft: nested_item["draft"]
       )
 
       child_taxons = links["child_taxons"]
@@ -93,7 +95,8 @@ module GovukTaxonomyHelpers
         title: nested_item["title"],
         internal_name: details["internal_name"],
         content_id: nested_item["content_id"],
-        base_path: nested_item["base_path"]
+        base_path: nested_item["base_path"],
+        draft: nested_item["draft"]
       )
 
       parent_taxons = links["parent_taxons"]

--- a/spec/linked_content_item_spec.rb
+++ b/spec/linked_content_item_spec.rb
@@ -2,8 +2,8 @@ require_relative 'spec_helper'
 require 'govuk_taxonomy_helpers/linked_content_item'
 
 RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
-  let(:root_node) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "root-id", content_id: "abc", base_path: "/root-id") }
-  let(:child_node_1) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-1-id", content_id: "abc", base_path: "/child-1-id") }
+  let(:root_node) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "root-id", content_id: "abc", base_path: "/root-id", draft: false) }
+  let(:child_node_1) { GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-1-id", content_id: "abc", base_path: "/child-1-id", draft: false) }
 
   describe "#<<(child_node)" do
     it "makes one node the child of another node" do
@@ -17,8 +17,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
   describe "#tree" do
     context "given a node with a tree of successors" do
       it "returns an array representing a pre-order traversal of the tree" do
-        child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
-        child_node_3 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-3-id", content_id: "abc", base_path: "/child-3-id")
+        child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id", draft: false)
+        child_node_3 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-3-id", content_id: "abc", base_path: "/child-3-id", draft: false)
 
         root_node << child_node_1
         child_node_1 << child_node_3
@@ -54,7 +54,7 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
 
   describe "#depth" do
     it "returns the depth of the node in its tree" do
-      child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id")
+      child_node_2 = GovukTaxonomyHelpers::LinkedContentItem.new(title: "child-2-id", content_id: "abc", base_path: "/child-2-id", draft: false)
       root_node << child_node_1
       child_node_1 << child_node_2
 
@@ -77,7 +77,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
       GovukTaxonomyHelpers::LinkedContentItem.new(
         title: "child-2-id",
         content_id: "abc",
-        base_path: "/child-2-id"
+        base_path: "/child-2-id",
+        draft: false
       )
     end
 
@@ -119,7 +120,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
         GovukTaxonomyHelpers::LinkedContentItem.new(
           title: "content",
           content_id: "abc",
-          base_path: "/content"
+          base_path: "/content",
+          draft: false
         )
       end
 
@@ -135,7 +137,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
         GovukTaxonomyHelpers::LinkedContentItem.new(
           title: "another-taxon",
           content_id: "abc",
-          base_path: "/another-taxon"
+          base_path: "/another-taxon",
+          draft: false
         )
       end
 
@@ -143,7 +146,8 @@ RSpec.describe GovukTaxonomyHelpers::LinkedContentItem do
         GovukTaxonomyHelpers::LinkedContentItem.new(
           title: "content",
           content_id: "abc",
-          base_path: "/content"
+          base_path: "/content",
+          draft: false
         )
       end
 

--- a/spec/publishing_api_response_spec.rb
+++ b/spec/publishing_api_response_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "GC 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       grandchild_2 = {
@@ -39,7 +40,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "GC 2",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       child_1 = {
@@ -54,7 +56,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
             grandchild_1,
             grandchild_2
           ]
-        }
+        },
+        "draft" => false
       }
 
       {
@@ -101,7 +104,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "C 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       child_2 = {
@@ -111,7 +115,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "C 2",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       {
@@ -138,7 +143,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "GP 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       parent_1 = {
@@ -152,7 +158,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
           "parent_taxons" => [
             grandparent_1
           ]
-        }
+        },
+        "draft" => false
       }
 
       {
@@ -180,7 +187,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "P 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       {
@@ -222,7 +230,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "P 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       parent_2 = {
@@ -232,7 +241,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "P 2",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       {
@@ -259,7 +269,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "details" => {
           "internal_name" => "GP 1",
         },
-        "links" => {}
+        "links" => {},
+        "draft" => false
       }
 
       parent_1 = {
@@ -271,7 +282,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         },
         "links" => {
           "parent_taxons" => [grandparent_1]
-        }
+        },
+        "draft" => false
       }
 
       taxon_1 = {
@@ -283,7 +295,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         },
         "links" => {
           "parent_taxons" => [parent_1]
-        }
+        },
+        "draft" => false
       }
 
       grandparent_2 = {
@@ -305,7 +318,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         },
         "links" => {
           "parent_taxons" => [grandparent_2]
-        }
+        },
+        "draft" => false
       }
 
       taxon_2 = {
@@ -317,7 +331,8 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         },
         "links" => {
           "parent_taxons" => [parent_2]
-        }
+        },
+        "draft" => false
       }
 
       {
@@ -347,12 +362,14 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
         "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandchild-1",
         "title" => "Grandchild 1",
+        "draft" => false,
       }
 
       grandchild_2 = {
         "content_id" => "94aadc14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/grandchild-2",
         "title" => "Grandchild 2",
+        "draft" => false,
       }
 
       child_1 = {
@@ -364,13 +381,15 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
             grandchild_1,
             grandchild_2
           ]
-        }
+        },
+        "draft" => false
       }
 
       content_item = {
         "content_id" => "aaaaaa14-9bca-40d9-abb4-4f21f9792a05",
         "base_path" => "/minimal-taxon",
         "title" => "Minimal Taxon",
+        "draft" => false,
       }
 
       expanded_links = {


### PR DESCRIPTION
This commit adds support for draft taxons to be marked as such. It is a generalised form of the changes at https://github.com/alphagov/whitehall/pull/3116.

Depends on https://github.com/alphagov/whitehall/pull/3116.

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall