### PR TITLE
Allow the gem to parse content items from the message queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add `LinkedContentItem.from_publishing_api_downstream` to parse publishing api message queue responses.
+
 ## 0.1.0
 
 * When parsing publishing api responses, allow both links and details hashes to

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ taxonomy = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
 )
 ```
 
+Message queue workers can also pass the fully expanded content item hash:
+
+```ruby
+taxonomy = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api_downstream(content_item)
+```
+
 A `LinkedContentItem` built from a taxon can access all *narrower term* taxons below it and all *broader term* taxons above it.
 
 A taxon may have many child taxons, but can only have one or zero parents.
@@ -51,7 +57,7 @@ taxon.breadcrumb_trail
 # => [LinkedContentItem(title: root, ...), LinkedContentItem(title: taxon, ...)]
 ```
 
-A `LinkedContentItem` built from an content_item that isn't a taxon can access all taxons associated with it.
+A `LinkedContentItem` built from a content item that isn't a taxon can access all taxons associated with it.
 
 ```ruby
 content_item.taxons

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -15,6 +15,17 @@ module GovukTaxonomyHelpers
         expanded_links: expanded_links,
       ).linked_content_item
     end
+
+    # Extract a LinkedContentItem from publishing api's message queue payload.
+    #
+    # @param expanded_content_item [Hash] Publishing API message queue payload
+    # @return [LinkedContentItem]
+    def self.from_publishing_api_downstream(expanded_content_item)
+      PublishingApiResponse.new(
+        content_item: expanded_content_item,
+        expanded_links: expanded_content_item,
+      ).linked_content_item
+    end
   end
 
   class PublishingApiResponse
@@ -37,10 +48,16 @@ module GovukTaxonomyHelpers
 
   private
 
+    def extract_links(item)
+      item["expanded_links"] || item["links"]
+    end
+
     def add_expanded_links(expanded_links_response)
-      child_taxons = expanded_links_response["expanded_links"]["child_taxons"]
-      parent_taxons = expanded_links_response["expanded_links"]["parent_taxons"]
-      taxons = expanded_links_response["expanded_links"]["taxons"]
+      direct_links = extract_links(expanded_links_response)
+
+      child_taxons = direct_links["child_taxons"]
+      parent_taxons = direct_links["parent_taxons"]
+      taxons = direct_links["taxons"]
 
       if !child_taxons.nil?
         child_taxons.each do |child|

--- a/spec/publishing_api_response_spec.rb
+++ b/spec/publishing_api_response_spec.rb
@@ -402,4 +402,48 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
       expect(minimal_taxon.descendants.map(&:internal_name)).to all(be_nil)
     end
   end
+
+  context "given a downstream response" do
+    let(:expanded_content_item) do
+      child_1 = {
+        "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/child-1",
+        "title" => "Child 1",
+        "details" => {
+          "internal_name" => "C 1",
+        },
+        "links" => {}
+      }
+
+      child_2 = {
+        "content_id" => "84aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/child-2",
+        "title" => "Child 2",
+        "details" => {
+          "internal_name" => "C 2",
+        },
+        "links" => {}
+      }
+
+      {
+        "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/taxon",
+        "title" => "Taxon",
+        "details" => {
+          "internal_name" => "My lovely taxon"
+        },
+        "links" => {
+          "child_taxons" => [child_1, child_2]
+        }
+      }
+    end
+
+    it "parses the taxonomy struture" do
+      taxon = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api_downstream(
+        expanded_content_item
+      )
+      expect(taxon.title).to eq("Taxon")
+      expect(taxon.children.map(&:title)).to eq(["Child 1", "Child 2"])
+    end
+  end
 end


### PR DESCRIPTION
Message queue consumers get a fully expanded content item with edition
information + links, whereas the REST API doesn't expose these in one request.
Add another helper to parse this format.

The API uses "expanded_links" whereas downstream it's just called "links". Just
pick whichever one is there.

This should help with https://github.com/alphagov/email-alert-service/pull/67/files