### PR TITLE
Fixes file requirements

### DIFF
--- a/lib/govuk_taxonomy_helpers.rb
+++ b/lib/govuk_taxonomy_helpers.rb
@@ -1,3 +1,5 @@
-require "govuk_taxonomy_helpers/version"
-require "govuk_taxonomy_helpers/publishing_api_response"
-require "govuk_taxonomy_helpers/linked_content_item"
+module GovukTaxonomyHelpers
+  Dir[File.dirname(__FILE__) + '/govuk_taxonomy_helpers/*.rb'].each do |file|
+    require file
+  end
+end

--- a/lib/govuk_taxonomy_helpers/linked_content_item.rb
+++ b/lib/govuk_taxonomy_helpers/linked_content_item.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module GovukTaxonomyHelpers
   # A LinkedContentItem can be anything that has a content store representation
   # on GOV.UK.

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -1,5 +1,3 @@
-require 'govuk_taxonomy_helpers/linked_content_item'
-
 module GovukTaxonomyHelpers
   class LinkedContentItem
     # Extract a LinkedContentItem from publishing api response data.


### PR DESCRIPTION
This commit fixes the gem requirements.
You can now require the gem in irb like so `irb -r ./lib/govuk_taxonomy_helpers` for example.
