### PR TITLE
Add from_from_content_id method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Adds the from_content_id builder method to LinkedContentItem
+
 ## 0.1.0
 
 * When parsing publishing api responses, allow both links and details hashes to

--- a/lib/govuk_taxonomy_helpers/publishing_api_response.rb
+++ b/lib/govuk_taxonomy_helpers/publishing_api_response.rb
@@ -13,6 +13,18 @@ module GovukTaxonomyHelpers
         expanded_links: expanded_links,
       ).linked_content_item
     end
+
+    # Use the publishing API service to fetch and extract a LinkedContentItem
+    #
+    # @param content_id [String] id of the content
+    # @param publishing_api [PublishingApiV2] Publishing API service
+    # @return [LinkedContentItem]
+    def self.from_content_id(content_id:, publishing_api:)
+      GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
+        content_item: publishing_api.get_content(content_id).to_h,
+        expanded_links: publishing_api.get_expanded_links(content_id).to_h
+      )
+    end
   end
 
   class PublishingApiResponse

--- a/spec/publishing_api_response_spec.rb
+++ b/spec/publishing_api_response_spec.rb
@@ -13,6 +13,37 @@ RSpec.describe GovukTaxonomyHelpers::PublishingApiResponse do
     }
   end
 
+  describe '#from_content_id - simple one child case' do
+    let(:expanded_links) do
+      child = {
+        "content_id" => "74aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "base_path" => "/child",
+        "title" => "Child",
+        "details" => {
+          "internal_name" => "C",
+        },
+        "links" => {}
+      }
+
+      {
+        "content_id" => "64aadc14-9bca-40d9-abb4-4f21f9792a05",
+        "expanded_links" => {
+          "child_taxons" => [child]
+        }
+      }
+    end
+    before :each do
+      @publishing_api = double('publishing_api')
+      allow(@publishing_api).to receive(:get_content).with('64aadc14-9bca-40d9-abb4-4f21f9792a05').and_return(content_item)
+      allow(@publishing_api).to receive(:get_expanded_links).with('64aadc14-9bca-40d9-abb4-4f21f9792a05').and_return(expanded_links)
+    end
+    it 'loads the taxon' do
+      expect(linked_content_item.title).to eq("Taxon")
+      expect(linked_content_item.children.map(&:title)).to eq(["Child"])
+      expect(linked_content_item.children.map(&:children)).to all(be_empty)
+    end
+  end
+
   let(:linked_content_item) do
     GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
       content_item: content_item,


### PR DESCRIPTION
Needed for: https://github.com/alphagov/content-tagger/pull/413

The`LinkedContentItem.from_publishing_api` method requires two hashes obtained from the Publishing API as follows:
```
  GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
        content_item: publishing_api.get_content(content_id).to_h,
        expanded_links: publishing_api.get_expanded_links(content_id).to_h
      )
```
The `from_from_content_id` method is a convenience method that makes this call and depends on content_id the publishing_api service