### PR TITLE
Add function to expand links for level one taxons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Merges from_content_id and from_publishing_api into one builder method contained
+in LinkedContentItem. The homepage can now have it's links expanded through
+it's level_one_taxons by using the content_id of the homepage to form a nested tree from
+the root.
+
 ## 0.1.1
 
 * Adds the from_content_id builder method to LinkedContentItem

--- a/README.md
+++ b/README.md
@@ -22,17 +22,14 @@ Or install it yourself as:
 
 The API is provisional and is likely to change for versions < 1.0.0.
 
-To access the taxonomy, first request the content from the [publishing api](https://github.com/alphagov/publishing-api), then parse it to get a `LinkedContentItem` object.
+To access the taxonomy, first get the content_id of the piece of content you want the taxonomy for, then parse it to get a `LinkedContentItem` object.
 
 ```ruby
 require 'govuk_taxonomy_helpers'
 
-content_item = Services.publishing_api.get_content("c75c541-403f-4cb1-9b34-4ddde816a80d")
-expanded_links = Services.publishing_api.get_expanded_links("c75c541-403f-4cb1-9b34-4ddde816a80d")
-
-taxonomy = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
-  content_item: content_item,
-  expanded_links: expanded_links
+taxonomy = GovukTaxonomyHelpers::LinkedContentItem.from_content_id(
+  content_id: "c75c541-403f-4cb1-9b34-4ddde816a80d",
+  publishing_api: Services.publishing_api
 )
 ```
 


### PR DESCRIPTION
LinkedContentItem can now expand the links of 'level_one_taxons' adding the
results to 'linked_content_item' which holds a nested tree from the
root taxon(homepage).