### PR TITLE
Update Jenkinsfile to use `main` branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
     stage('Clean') {
       govuk.cleanupGit()
-      govuk.mergeMasterBranch()
+      govuk.mergeIntoBranch("main")
     }
 
     stage('Bundle') {


### PR DESCRIPTION
This was missed in https://github.com/alphagov/govuk_taxonomy_helpers/pull/21/files