### PR TITLE
Document project archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GovukTaxonomyHelpers
 
+**This project was archived in October 2022, the functionality has been ported into [content-tagger](https://github.com/alphagov/content-tagger/pull/1391).**
+
 Parses the taxonomy of GOV.UK into a browseable tree structure.
 
 ## Installation


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

We are archiving this gem because the functionality has now been ported to the content-tagger project. This is a change to the readme that will remain in posterity once the repository is archived.

This code was ported to content-tagger as that was the only application that was using this gem.